### PR TITLE
FIX-resolved-freedom-rains-FE-runtime-error

### DIFF
--- a/client/src/utils/account-utils.js
+++ b/client/src/utils/account-utils.js
@@ -24,6 +24,9 @@ export const setUserAccount = (account) => {
 };
 
 export const getLoginToken = () => {
+  if (document.cookie.indexOf('token=') === -1) {
+    return undefined; 
+  }
   const loginToken = document.cookie.substring(
     document.cookie.indexOf('token=') + 'token='.length, 
     document.cookie.indexOf(';', document.cookie.indexOf('token='))


### PR DESCRIPTION
I added an `if` condition on getLoginToken method that was created by Tahmidul on his last PR to check whether a token exists in a document.cookie. 

Basically, we just forgot to return undefined in the getLoginToken function in the case token does not exist in the cookie. 

As soon as this PR gets merged, the runtime error in FE should be resolved and our prod should be good to go!