### PR TITLE
FIX: Price Tracking Bug for Products on Amazon

### DIFF
--- a/server/controllers/scrapControllers/utils/productPage.js
+++ b/server/controllers/scrapControllers/utils/productPage.js
@@ -22,12 +22,11 @@ module.exports.macysProduct = ($) => {
     image: image,
   };
 };
-
 module.exports.amazonProduct = ($) => {
-  const p1 = $('#priceblock_saleprice');
-  const p2 = $('#priceblock_ourprice');
-  const p3 = $('#price');
-  const p4 = $('#price_inside_buybox');
+  const p1 = $('.priceToPay > .a-offscreen'); // Old: #priceblock_saleprice
+  const p2 = $('.savingPriceOverride'); // Old: #priceblock_outprice
+  const p3 = $('.basisPrice > .a-price > .a-offscreen'); // Old: #price
+  const p4 = $('.priceToPay > .a-offscreen'); // Old: #price_inside_buybox
 
   const sale = p1 ? p1.text().replace(/\n|\$/gi, '') : null;
   const price = p2

--- a/server/controllers/scrapControllers/utils/productPage.js
+++ b/server/controllers/scrapControllers/utils/productPage.js
@@ -23,10 +23,10 @@ module.exports.macysProduct = ($) => {
   };
 };
 module.exports.amazonProduct = ($) => {
-  const p1 = $('.priceToPay > .a-offscreen'); // Old: #priceblock_saleprice
-  const p2 = $('.savingPriceOverride'); // Old: #priceblock_outprice
-  const p3 = $('.basisPrice > .a-price > .a-offscreen'); // Old: #price
-  const p4 = $('.priceToPay > .a-offscreen'); // Old: #price_inside_buybox
+  const p1 = $('.priceToPay > .a-offscreen').eq(0); // Old: #priceblock_saleprice
+  const p2 = $('.savingPriceOverride').eq(0); // Old: #priceblock_outprice
+  const p3 = $('.basisPrice > .a-price > .a-offscreen').eq(0); // Old: #price
+  const p4 = $('.priceToPay > .a-offscreen').eq(0); // Old: #price_inside_buybox
 
   const sale = p1 ? p1.text().replace(/\n|\$/gi, '') : null;
   const price = p2


### PR DESCRIPTION
`NOTE: This PR has two parts, one on the backend (this) and the other on the browser extension.`

On the Backend:
- Changed HTML selectors for price fetching
- Should now only fetch the first value instead of 'all' the values.
    - "All" refers to the new, used, and other sellers' prices.
    - Now, it should just return the price that is shown first in the topmost box